### PR TITLE
Add logging for failed web call

### DIFF
--- a/promote/main.py
+++ b/promote/main.py
@@ -18,6 +18,7 @@ def repoxGetPropertyFromBuildInfo(project, buildNumber, property):
   if r.status_code == 200:      
     return buildInfo['buildInfo']['properties'][property]
   else:
+    print(f'repoxGetPropertyFromBuildInfo call with URL {url} failed, the response is {buildInfo}')
     raise Exception('unknown build')
 
 def validateAutorizationHeader(request):


### PR DESCRIPTION
the format of the message is like

> repoxGetPropertyFromBuildInfo call with URL <ARTIFACTORY_URL>/api/build/andrei-parent/12 failed, the response is {'errors': [{'status': 404, 'message': 'No build was found for build name: andrei-parent, build number: 12 '}]}
