### PR TITLE
Update build tools for .NET 5 compatibility

### DIFF
--- a/windows/lt-base-windows-dotnet.json
+++ b/windows/lt-base-windows-dotnet.json
@@ -54,7 +54,7 @@
         "choco install nuget.commandline --version 5.8.0",
         "choco install sonarscanner-msbuild-net46 --version=4.10.0.19059",
         "choco install sonarscanner-msbuild-netcoreapp2.0 --version=4.10.0.19059",
-        "choco install visualstudio2019buildtools --version 16.8.2.0 --package-parameters \"--allWorkloads --includeRecommended --includeOptional --passive --locale en-US\"",
+        "choco install visualstudio2019buildtools --version 16.8.2.0 --package-parameters \"--allWorkloads --includeRecommended --includeOptional\"",
         "choco install visualstudio2019-workload-webbuildtools",
         "choco install visualstudio2019-workload-manageddesktopbuildtools",
         "choco install dotnetfx --version=4.8.0.20190930",

--- a/windows/lt-base-windows-dotnet.json
+++ b/windows/lt-base-windows-dotnet.json
@@ -51,17 +51,17 @@
       "type": "powershell",
       "inline": [
         "choco install 7zip --version 19.0",
-        "choco install nuget.commandline --version 5.3.0",
+        "choco install nuget.commandline --version 5.8.0",
         "choco install sonarscanner-msbuild-net46 --version=4.10.0.19059",
         "choco install sonarscanner-msbuild-netcoreapp2.0 --version=4.10.0.19059",
-        "choco install visualstudio2019buildtools --version=16.3.6.0",
+        "choco install visualstudio2019buildtools --version 16.8.2.0 --package-parameters \"--allWorkloads --includeRecommended --includeOptional --passive --locale en-US\"",
         "choco install visualstudio2019-workload-webbuildtools",
         "choco install visualstudio2019-workload-manageddesktopbuildtools",
         "choco install dotnetfx --version=4.8.0.20190930",
         "choco install netfx-4.8-devpack --version 4.8.0.20190930",
         "choco install openjdk11 --version 11.0.8.10",
         "choco install maven --version 3.6.2",
-        "choco install git --version 2.28.0 --package-parameters \"/GitAndUnixToolsOnPath /NoShellIntegration\"",
+        "choco install git --version 2.29.2.2 --package-parameters \"/GitAndUnixToolsOnPath /NoShellIntegration\"",
         "choco install nodejs-lts --version 12.18.3"
       ]
     },


### PR DESCRIPTION
The error on sonar-security build:
```C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(241,5): error NETSDK1005: Assets file 'C:\Windows\TEMP\cirrus-ci-build\its\projects\internal\InternalCSharp\InternalCSharp.NetFramework48\obj\project.assets.json' doesn't have a target for 'net48'. Ensure that restore has run and that you have included 'net48' in the TargetFrameworks for your project. [C:\Windows\TEMP\cirrus-ci-build\its\projects\internal\InternalCSharp\InternalCSharp.NetFramework48\InternalCSharp.NetFramework48.csproj]```

> This happens because NuGet writes a file named project.assets.json in the obj\ folder & the .NET SDK uses it to get information about packages to pass into the compiler. In .NET 5, Nuget added a new field called TargetFrameworkAlias, and thus in MSBuild versions < 16.8 or NuGet versions < 5.8, it is possible that you can generate an assets file without the TargetFrameworkAlias as it will read the property and not find it. You can resolve this issue by ensuring you are on MSBuild version 16.8+ & using NuGet version 5.8+.

([source](https://developercommunity.visualstudio.com/content/problem/1248649/error-netsdk1005-assets-file-projectassetsjson-doe.html))

Also, the official [Getting Started With NuGet 5.8](https://devblogs.microsoft.com/nuget/getting-started-with-nuget-5-8/) blog post says

> It is advised to ensure that you are on the same version of tooling in your environments. Visual Studio 16.8, MSBuild 16.8, and .NET 5.0 require NuGet 5.8 or later.

Also, update git to the latest, to be able to authenticate via token.