### PR TITLE
Build v8 and improve docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,6 @@
 gcp_credentials: ENCRYPTED[!17c59813193e86cc337bce848b358412b90f50bc5fe1b8b39d363cdf14a41ebe76cfba0482e7f81d076994b9f6dbfb4c!]
 
 image_build_task:
-  # !README! comment out the below `only_if` to build a new image (currently, this task will be skipped)
-  # don't forget to increment the TAG in the `build-packer-image.sh` script!
-  only_if: false
   auto_cancellation: false
   gce_instance:
     image_project: ubuntu-os-cloud
@@ -20,7 +17,6 @@ image_build_task:
   build_script: bash build-packer-image.sh
 
 test_windows_task:
-  #only_if: false
   depends_on:
    - image_build
   gce_instance:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Increment `TAG` in `./build-packer-image.sh`.
 
-Merge/Commit to the master will create `lt-base-windows-dotnet-vXX` image **with** the image family where `vXX` is the TAG.
+Merge/Commit to the `master` branch will create `lt-base-windows-dotnet-vXX` image **with** the image family where `vXX` is the TAG.
 
 PR commits will create `lt-base-windows-dotnet-pull-request-XX` image **without** the image family where `XX` is a PR number.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # buildTools
 
-# Before building for your own GCP project
+## Create new image version
 
-## Create WinRM firewall rule
+Increment `TAG` in `./build-packer-image.sh`.
+
+Merge/Commit to the master will create `lt-base-windows-dotnet-vXX` image **with** the image family where `vXX` is the TAG.
+
+PR commits will create `lt-base-windows-dotnet-pull-request-XX` image **without** the image family where `XX` is a PR number.
+
+Use `[skip ci]` in a commit message to avoid creating the new image (see [docs](https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution)). 
+
+## Images
+
+Images are in [Google Cloud Platform](https://console.cloud.google.com/compute/images?organizationId=472937710676&project=language-team). 
+
+The latest image with `lt-base-windows-dotnet` family is used by the build jobs.
+
+### Manual cleanup
+
+We should keep only last 5 versions in GCP. Delete older images manually.
+
+## Before building for your own GCP project
+
+### Create WinRM firewall rule
 
 By default traffic on `tcp:5986` is not allowed so we need to add a firewall rule for a project we want to build images for:
 

--- a/build-packer-image.sh
+++ b/build-packer-image.sh
@@ -2,10 +2,12 @@
 
 set -euo pipefail
 
+#See README.md to understand branches, naming and versioning.
+
 TAG=v8
 
 if [ "${CIRRUS_PR:-}" != "" ]; then
-  TAG=$CIRRUS_PR
+  TAG=pull-request-$CIRRUS_PR
   export IMAGE_FAMILY=
 elif [ $CIRRUS_BRANCH == "lt-base-windows-dotnet" ]; then
   export IMAGE_FAMILY=lt-base-windows-dotnet

--- a/build-packer-image.sh
+++ b/build-packer-image.sh
@@ -13,6 +13,7 @@ elif [ $CIRRUS_BRANCH == "lt-base-windows-dotnet" ]; then
   export IMAGE_FAMILY=lt-base-windows-dotnet
 else
   echo "Not building image for feature branch"
+  exit
 fi
 
 export IMAGE_NAME=lt-base-windows-dotnet-${TAG}


### PR DESCRIPTION
There's no `[skip ci]` on PR to verify the `pull-request-xx` naming.

There should be no `[skip ci]` to build the new image on master.