### PR TITLE
BUILD-1021 Prevent printing script content

### DIFF
--- a/bin/cirrus-env
+++ b/bin/cirrus-env
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set +o verbose
 set -euo pipefail
 
 # generic environment variables used by Gradle build
@@ -50,3 +51,5 @@ fi
 case $BUILD_ID in
     ''|*[!0-9]*) echo "$BUILD_ID is not a number" && exit 1 ;;    
 esac
+
+set -o verbose


### PR DESCRIPTION
Unset the verbose flag, enabled by cirrus ci.

For more infos: #https://xtranet-sonarsource.atlassian.net/l/c/QWQ7sHzY