### PR TITLE
SONARSEC-2887: update source_image_family to windows-2022-core

### DIFF
--- a/windows/lt-base-windows-dotnet.json
+++ b/windows/lt-base-windows-dotnet.json
@@ -8,7 +8,7 @@
       "type": "googlecompute",
       "account_file": "account.json",
       "project_id": "language-team",
-      "source_image_family": "windows-2004-core",
+      "source_image_family": "windows-2022-core",
       "image_name": "{{user `image_name`}}",
       "image_family": "{{user `image_family`}}",
       "disk_size": "128",


### PR DESCRIPTION
The image was tested in this PR https://github.com/SonarSource/sonar-security/pull/3047.