### PR TITLE
Install dotnet 6 on VM image

### DIFF
--- a/windows/scripts/Install-DotNetSdk.ps1
+++ b/windows/scripts/Install-DotNetSdk.ps1
@@ -1,3 +1,4 @@
 choco install dotnetcore-sdk --version 2.1.815
 choco install dotnetcore-sdk --version 3.1.408
 choco install dotnet-sdk --version 5.0.202
+choco install dotnet-sdk --version 6.0.200


### PR DESCRIPTION
In order to add a reproducer IT for https://jira.sonarsource.com/browse/SONARSEC-2895, the VM has to contain dotnet 6 installed.

The change was tested in https://github.com/SonarSource/sonar-security/pull/3050.
And also with the net6 ITs here: https://github.com/SonarSource/sonar-security/pull/3042